### PR TITLE
Fallback to language code in case it is equal to country code

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,6 +21,13 @@ Quick start
 
     {% load language_flags_tags %}
 
+   and include css or min.css in HTML ``<head>``::
+
+    <link rel="stylesheet" type="text/css" href="{% static 'css/flags.css' %}">
+
+   Don't forget ``{% load staticfiles %}`` at the top of your template.
+
+
 3. You can use the `flags_for_language` tag to display a number
    of flags of nations where a language is spoken. Right now the
    language can be either English or German::

--- a/src/language_flags/templatetags/language_flags_tags.py
+++ b/src/language_flags/templatetags/language_flags_tags.py
@@ -18,7 +18,7 @@ language_flags = {
 @register.inclusion_tag('language_flags/flagrow.html', takes_context=True)
 def flags_for_language(context, count, language):
     count = int(count)
-    flags = language_flags[language]
+    flags = language_flags.get(language, [language])
     if len(flags) > count:
         flags = [flags[0]] + random.sample(flags[1:], count-1)
     return {'STATIC_URL': settings.STATIC_URL, 'flags': flags}


### PR DESCRIPTION
Original code is based on a small dictionary where only two languages are considered.

This small improvement provides a possibility to display other language flags too, as long as their language code is equal to the flag code, e.g. `pl` for Polish (Poland).

Also: Added CSS and `load staticfiles` to README so that nobody will skratch their head after the `language_flags` app is added.